### PR TITLE
Keycloak.X image for Quarkus Dev Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,9 @@
+# Keycloak.x for Kubernetes
 
+Keycloak.x is configured at build time,
+thus needs more variants than legacy keycloak.
 
-### Configuration, JGroups
+We build example variants using [docker-compose --build](./docker-compose.yml).
 
-Current default startup:
-
-```
-2020-07-18 03:27:02,330 INFO  [org.inf.fac.GlobalComponentRegistry] (main) ISPN000128: Infinispan version: Infinispan 'Infinity Minus ONE +2' 9.4.18.Final
-2020-07-18 03:27:02,536 INFO  [org.inf.rem.tra.jgr.JGroupsTransport] (main) ISPN000078: Starting JGroups channel ISPN
-2020-07-18 03:27:02,536 INFO  [org.inf.rem.tra.jgr.JGroupsTransport] (main) ISPN000088: Unable to use any JGroups configuration mechanisms provided in properties {}. Using default JGroups configuration!
-```
-
-Status:
-- https://github.com/infinispan/infinispan/blob/master/core/src/main/resources/default-configs/default-jgroups-tcp.xml
-- https://github.com/keycloak/keycloak/blob/f15821fe69c4f7e9c22c63dd7191c69e77702b58/quarkus/runtime/src/main/java/org/keycloak/provider/quarkus/QuarkusCacheManagerProvider.java#L48
-- https://infinispan.org/docs/9.4.x/server_guide/server_guide.html
-- https://infinispan.org/docs/9.4.x/server_guide/server_guide.html#server_config_jgroups
-- https://github.com/keycloak/keycloak/commit/1db1deb0668b01eafa5dd03b222f51699be48008
-- https://github.com/keycloak/keycloak/commit/b04932ede56993d36de70768c41d4c946c4c79e0#diff-d6997f5a4578cd9576ae6f1fdb5739db
-- https://github.com/keycloak/keycloak/tree/master/quarkus/runtime/src/main/resources
-- https://github.com/keycloak/keycloak/blob/master/quarkus/server/src/main/resources/META-INF/keycloak.properties
-
-### Testing the image
-
-```
-docker build -t keycloakx .
-docker run --rm --entrypoint java keycloakx -Dquarkus.datasource.url='jdbc:h2:file:/home/nonroot/data/keycloakdb;;AUTO_SERVER=TRUE' <args from docker run --rm keycloakx>
-```
+See:
+- [./quarkus-dev/](Quarkus Dev Services replacement image).

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ thus needs more variants than legacy keycloak.
 We build example variants using [docker-compose --build](./docker-compose.yml).
 
 See:
-- [./quarkus-dev/](Quarkus Dev Services replacement image).
+- [Quarkus Dev Services replacement image](./quarkus-dev/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,53 +2,11 @@ version: '2.4'
 
 services:
 
-  mysql:
-    image: mariadb:10.3.33@sha256:74ec811b4dd9580f6c6a110e46123e72b9d1eac930cff505e2d8e3e658edc804
-    expose:
-    - "3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: insecure-local-instance
-      MYSQL_DATABASE: keycloak
-      MYSQL_USER: keycloak
-      MYSQL_PASSWORD: keycloak
-    # https://issues.jboss.org/browse/KEYCLOAK-3873
-    command:
-    - --character-set-server=utf8
-    - --collation-server=utf8_unicode_ci
-
-  keycloakx1:
+  dev-quarkus:
+    image: yolean/keycloakx:dev-quarkus
     build:
-      context: .
-      args:
-        cluster: local
-    depends_on:
-    - mysql
-    ports:
-    - 8080:8080
-    volumes:
-    - ./conf:/opt/keycloak.x/conf
-    # With kc.sh patched, by Dockerfile, to only do echo:
-    # entrypoint:
-    # - java
-    command:
-    - -Dkc.db.url.host=mysql:3306
-    - -Dkc.db.url.database=keycloak
-    - -Dkc.db.url.properties='characterEncoding=UTF-8'
-    - -Dkc.db.url.username=keycloak
-    - -Dkc.db.url.password=keycloak
-    # # the remainder is generated from the kc.sh patched by Dockerfile
-    # - -Xms64m
-    # - -Xmx512m
-    # - -XX:MetaspaceSize=96M
-    # - -XX:MaxMetaspaceSize=256m
-    # - -Djava.net.preferIPv4Stack=true
-    # - -Dkeycloak.home.dir=/opt/keycloak.x/bin/../
-    # - -Djboss.server.config.dir=/opt/keycloak.x/bin/../conf
-    # - -Dkeycloak.theme.dir=/opt/keycloak.x/bin/../themes
-    # - -Djava.util.logging.manager=org.jboss.logmanager.LogManager
-    # - -cp
-    # -    /opt/keycloak.x/bin/../lib/quarkus-run.jar:/opt/keycloak.x/bin/../lib/main/*
-    # - io.quarkus.bootstrap.runner.QuarkusEntryPoint
-    - --datasource-username=keycloak \
-    - --datasource-password=keycloak \
-    - --datasource-url=jdbc:mariadb://mysql:3306/keycloak?characterEncoding=UTF-8
+      context: quarkus-dev
+    entrypoint:
+    - /opt/jboss/keycloak/bin/kc.sh
+    - show-config
+    command: []

--- a/quarkus-dev/Dockerfile
+++ b/quarkus-dev/Dockerfile
@@ -8,5 +8,3 @@ ENV KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=admin
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 COPY docker-entrypoint-with-proxy.sh /opt/jboss/tools/docker-entrypoint-with-proxy.sh
 ENTRYPOINT [ "/opt/jboss/tools/docker-entrypoint-with-proxy.sh" ]
-
-# fails on https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L342

--- a/quarkus-dev/Dockerfile
+++ b/quarkus-dev/Dockerfile
@@ -1,0 +1,12 @@
+FROM envoyproxy/envoy:v1.19.0 as envoy
+
+FROM quay.io/keycloak/keycloak-x:14.0.0
+
+CMD ["start-dev"]
+ENV KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=admin
+
+COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
+COPY docker-entrypoint-with-proxy.sh /opt/jboss/tools/docker-entrypoint-with-proxy.sh
+ENTRYPOINT [ "/opt/jboss/tools/docker-entrypoint-with-proxy.sh" ]
+
+# fails on https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L342

--- a/quarkus-dev/README.md
+++ b/quarkus-dev/README.md
@@ -1,6 +1,6 @@
 # Keycloak.x for Quarkus dev mode
 
-The initial [https://github.com/quarkusio/quarkus/pull/17364/files](DevServices support for Keycloak) uses the default Keycloak distribution,
+The initial [DevServices support for Keycloak](https://github.com/quarkusio/quarkus/pull/17364) uses the default Keycloak distribution,
 instead of the leaner Keycloak.x ["Preview"](https://www.keycloak.org/downloads).
 
 While Quarkus dev depends on [hard coded](https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L169) [paths](https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L342)

--- a/quarkus-dev/README.md
+++ b/quarkus-dev/README.md
@@ -1,0 +1,20 @@
+# Keycloak.x for Quarkus dev mode
+
+The initial [https://github.com/quarkusio/quarkus/pull/17364/files](DevServices support for Keycloak) uses the default Keycloak distribution,
+instead of the leaner Keycloak.x ["Preview"](https://www.keycloak.org/downloads).
+
+While Quarkus dev depends on [hard coded](https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L169) [paths](https://github.com/quarkusio/quarkus/blob/2.1.0.Final/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java#L342)
+this image includes a proxy so that Keycloak.x can be used instead.
+
+In your `application.properties` use our prebuilt image or your local build like so:
+
+```
+quarkus.keycloak.devservices.image-name=yolean/keycloakx:dev-quarkus
+```
+
+The differences between the [default](https://quay.io/quay.io/keycloak/keycloak) keycloak image and [keycloak-x](quay.io/keycloak/keycloak-x) are captured in our
+[envoy proxy path rewrites](./docker-entrypoint-with-proxy.sh#L60).
+
+Access logs are available using `docker exec [container name from docker ps] tail -f /tmp/envoy.log`.
+
+In Kubernetes the proxy can run more elegantly as a sidecar.

--- a/quarkus-dev/docker-entrypoint-with-proxy.sh
+++ b/quarkus-dev/docker-entrypoint-with-proxy.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -eou pipefail
+
+echo "Starting envoy proxy in background ..."
+exec /usr/local/bin/envoy --log-level info --config-yaml '
+admin:
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 9901
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.file
+            filter:
+              not_health_check_filter: {}
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: "/dev/stdout"
+              log_format:
+                json_format:
+                  start_time: "%START_TIME%"
+                  req_method: "%REQ(:METHOD)%"
+                  req_path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                  resp_code: "%RESPONSE_CODE%"
+                  resp_flags: "%RESPONSE_FLAGS%"
+                  bytes_recv: "%BYTES_RECEIVED%"
+                  bytes_sent: "%BYTES_SENT%"
+                  duration: "%DURATION%"
+                  agent: "%REQ(USER-AGENT)%"
+                  req_id: "%REQ(X-REQUEST-ID)%"
+                  upstream_host: "%UPSTREAM_HOST%"
+                  upstream_cluster: "%UPSTREAM_CLUSTER%"
+                  resp_upstream_service_time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+                  resp_redirect: "%RESP(LOCATION)%"
+                  req_host: "%REQ(:AUTHORITY)%"
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  path: "/auth"
+                redirect:
+                  path_redirect: "/admin"
+              - match:
+                  prefix: "/auth/realms"
+                route:
+                  prefix_rewrite: "/realms"
+                  cluster: keycloak
+              # - match:
+              #     prefix: "/auth"
+              #   route:
+              #     prefix_rewrite: "/admin"
+              #     cluster: keycloak
+              # - match:
+              #     prefix: "/realms"
+              #   route:
+              #     prefix_rewrite: "/admin"
+              #     cluster: keycloak
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: keycloak
+          http_filters:
+          - name: envoy.filters.http.router
+  clusters:
+  - name: keycloak
+    connect_timeout: 30s
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: keycloak
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8081
+' >/tmp/envoy.log 2>/tmp/envoy.log &
+echo "Starting keycloak ..."
+exec /opt/jboss/tools/docker-entrypoint.sh $@ --http-port=8081

--- a/quarkus-dev/docker-entrypoint-with-proxy.sh
+++ b/quarkus-dev/docker-entrypoint-with-proxy.sh
@@ -62,16 +62,6 @@ static_resources:
                 route:
                   prefix_rewrite: "/realms"
                   cluster: keycloak
-              # - match:
-              #     prefix: "/auth"
-              #   route:
-              #     prefix_rewrite: "/admin"
-              #     cluster: keycloak
-              # - match:
-              #     prefix: "/realms"
-              #   route:
-              #     prefix_rewrite: "/admin"
-              #     cluster: keycloak
               - match:
                   prefix: "/"
                 route:


### PR DESCRIPTION
Because I was disappointed that quarkusio/quarkus#17364 uses "legacy" keycloak. The more microservices friendly Keycloak.X distribution surely needs some momentum.

We aim to eventually run Keycloak.x in production because the startup time for stock Wildfly based Keycloak, with a runtime .cli for customizations, is >5min which is impractical on ephemeral infra.

On my modestly spec'd dev machine `quarkus:dev` reports a startup time of 8s for this image vs. 17s for the default image. Memory consumption is ~330MB vs ~580MB.

Upstream Quarkus changes to support both images would obviously be preferrable over having a proxy process running in background in the container, but that's a different project.